### PR TITLE
Implement framework for building annotables

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -2,3 +2,4 @@
 ^\.Rproj\.user$
 README.*
 .git*
+^data-raw$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: annotables
 Type: Package
 Title: Ensembl Annotation Tables
-Version: 0.1.1
+Version: 0.1.2.9000
 Author: Stephen Turner
 Maintainer: Stephen Turner <vustephen@gmail.com>
 Description: Provides tables for converting and annotating Ensembl Gene IDs.
@@ -10,5 +10,6 @@ LazyData: TRUE
 Depends:
     R (>= 3.1.2)
 Suggests:
-    dplyr
+    dplyr,
+    yaml
 RoxygenNote: 5.0.1

--- a/data-raw/build-annotables.r
+++ b/data-raw/build-annotables.r
@@ -1,0 +1,36 @@
+library(yaml)
+library(dplyr)
+library(biomaRt)
+
+# load recipes
+recipe.files <- dir("data-raw/recipes", full.names = TRUE)
+names(recipe.files) <- sub(".yml", "", basename(recipe.files))
+
+recipes <- lapply(recipe.files, yaml::yaml.load_file)
+
+# download
+genetables <- lapply(recipes, function(x) {
+  mart <- biomaRt::useMart(x$biomart, x$dataset, x$host)
+  attr <- unlist(x$attributes, use.names = FALSE)
+  biomaRt::getBM(attr, mart = mart)
+})
+
+# tidy
+fix_genes <- function(x, recipe) {
+  dplyr::tbl_df(x) %>%
+    dplyr::distinct() %>%
+    dplyr::rename_(.dots = recipe$attributes)
+}
+
+genetables <- Map(fix_genes, x = genetables, recipe = recipes)
+
+# export
+paths <- file.path("data2", paste0(names(genetables), ".rda"))
+envir <- list2env(genetables)
+
+mapply(
+  save,
+  list = names(genetables),
+  file = as.list(paths),
+  MoreArgs = list(envir = envir, compress = "bzip2")
+)

--- a/data-raw/recipes/bdgp6.yml
+++ b/data-raw/recipes/bdgp6.yml
@@ -1,0 +1,13 @@
+host: ensembl.org
+biomart: ENSEMBL_MART_ENSEMBL
+dataset: dmelanogaster_gene_ensembl
+attributes:
+  ensgene: ensembl_gene_id
+  entrez: entrezgene
+  symbol: external_gene_name
+  chr: chromosome_name
+  start: start_position
+  end: end_position
+  strand: strand
+  biotype: gene_biotype
+  description: description

--- a/data-raw/recipes/galgal4.yml
+++ b/data-raw/recipes/galgal4.yml
@@ -1,0 +1,13 @@
+host: ensembl.org
+biomart: ENSEMBL_MART_ENSEMBL
+dataset: ggallus_gene_ensembl
+attributes:
+  ensgene: ensembl_gene_id
+  entrez: entrezgene
+  symbol: external_gene_name
+  chr: chromosome_name
+  start: start_position
+  end: end_position
+  strand: strand
+  biotype: gene_biotype
+  description: description

--- a/data-raw/recipes/grch37.yml
+++ b/data-raw/recipes/grch37.yml
@@ -1,0 +1,13 @@
+host: grch37.ensembl.org
+biomart: ENSEMBL_MART_ENSEMBL
+dataset: hsapiens_gene_ensembl
+attributes:
+  ensgene: ensembl_gene_id
+  entrez: entrezgene
+  symbol: external_gene_name
+  chr: chromosome_name
+  start: start_position
+  end: end_position
+  strand: strand
+  biotype: gene_biotype
+  description: description

--- a/data-raw/recipes/grch38.yml
+++ b/data-raw/recipes/grch38.yml
@@ -1,0 +1,13 @@
+host: ensembl.org
+biomart: ENSEMBL_MART_ENSEMBL
+dataset: hsapiens_gene_ensembl
+attributes:
+  ensgene: ensembl_gene_id
+  entrez: entrezgene
+  symbol: external_gene_name
+  chr: chromosome_name
+  start: start_position
+  end: end_position
+  strand: strand
+  biotype: gene_biotype
+  description: description

--- a/data-raw/recipes/grcm38.yml
+++ b/data-raw/recipes/grcm38.yml
@@ -1,0 +1,13 @@
+host: ensembl.org
+biomart: ENSEMBL_MART_ENSEMBL
+dataset: mmusculus_gene_ensembl
+attributes:
+  ensgene: ensembl_gene_id
+  entrez: entrezgene
+  symbol: external_gene_name
+  chr: chromosome_name
+  start: start_position
+  end: end_position
+  strand: strand
+  biotype: gene_biotype
+  description: description

--- a/data-raw/recipes/rnor6.yml
+++ b/data-raw/recipes/rnor6.yml
@@ -1,0 +1,13 @@
+host: ensembl.org
+biomart: ENSEMBL_MART_ENSEMBL
+dataset: rnorvegicus_gene_ensembl
+attributes:
+  ensgene: ensembl_gene_id
+  entrez: entrezgene
+  symbol: external_gene_name
+  chr: chromosome_name
+  start: start_position
+  end: end_position
+  strand: strand
+  biotype: gene_biotype
+  description: description

--- a/data-raw/recipes/wbcel235.yml
+++ b/data-raw/recipes/wbcel235.yml
@@ -1,0 +1,13 @@
+host: ensembl.org
+biomart: ENSEMBL_MART_ENSEMBL
+dataset: celegans_gene_ensembl
+attributes:
+  ensgene: ensembl_gene_id
+  entrez: entrezgene
+  symbol: external_gene_name
+  chr: chromosome_name
+  start: start_position
+  end: end_position
+  strand: strand
+  biotype: gene_biotype
+  description: description


### PR DESCRIPTION
This PR implements a (really simple) homebrew-inspired framework for building/updating annotables. 

The basic idea: each annotable is built from a YAML-based file that lives in `data-raw/recipes` and provides all of the info necessary for calling `getBM()`. Plus, the key/value pairs in the `attributes` block are used to rename the columns. 

This would make it easy for others to contribute new recipes or just build custom annotables locally. 

Note: `build-annotables.r` doesn't currently build the transcript-centric tables.