### PR TITLE
Autogenerate data documentation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,5 +11,6 @@ Depends:
     R (>= 3.1.2)
 Suggests:
     dplyr,
-    yaml
+    yaml,
+    whisker
 RoxygenNote: 5.0.1

--- a/R/bdgp6.R
+++ b/R/bdgp6.R
@@ -1,9 +1,25 @@
-#' Fly annotation BDGP6
+#' Fruitfly annotation data
 #'
-#' Fly annotation BDGP6 from Ensembl.
+#' Fruitfly (\emph{Drosophila melanogaster}) annotations based on genome assembly BDGP6 from Ensembl.
+#'
+#' Variables:
+#'
+#' \itemize{
+#'   \item ensgene 
+#'   \item entrez 
+#'   \item symbol 
+#'   \item chr 
+#'   \item start 
+#'   \item end 
+#'   \item strand 
+#'   \item biotype 
+#'   \item description 
+#' }
 #'
 #' @examples
 #' head(bdgp6)
 #'
-#' @source \url{http://useast.ensembl.org/Drosophila_melanogaster}
+#' @source \url{http://ensembl.org/drosophila_melanogaster}
+#' @docType data
+#' @keywords datasets
 "bdgp6"

--- a/R/bdgp6_tx2gene.R
+++ b/R/bdgp6_tx2gene.R
@@ -1,9 +1,18 @@
-#' Fly BDGP6 transcripts to genes
+#' Fruitfly transcripts to genes
 #'
-#' Fly BDGP6 Ensembl transcript IDs to gene IDs.
+#' Lookup table for converting Fruitfly (\emph{Drosophila melanogaster}) Ensembl transcript IDs to gene IDs based on genome assembly BDGP6_TX2GENE from Ensembl.
+#'
+#' Variables:
+#'
+#' \itemize{
+#'   \item enstxp 
+#'   \item ensgene 
+#' }
 #'
 #' @examples
 #' head(bdgp6_tx2gene)
 #'
-#' @source \url{http://www.ensembl.org/}
+#' @source \url{http://ensembl.org/drosophila_melanogaster}
+#' @docType data
+#' @keywords datasets
 "bdgp6_tx2gene"

--- a/R/bdgp6_tx2gene.R
+++ b/R/bdgp6_tx2gene.R
@@ -1,6 +1,6 @@
 #' Fruitfly transcripts to genes
 #'
-#' Lookup table for converting Fruitfly (\emph{Drosophila melanogaster}) Ensembl transcript IDs to gene IDs based on genome assembly BDGP6_TX2GENE from Ensembl.
+#' Lookup table for converting Fruitfly (\emph{Drosophila melanogaster}) Ensembl transcript IDs to gene IDs based on genome assembly BDGP6 from Ensembl.
 #'
 #' Variables:
 #'

--- a/R/galgal5.R
+++ b/R/galgal5.R
@@ -1,9 +1,25 @@
-#' Chicken annotation Galgal5
+#' Chicken annotation data
 #'
-#' Chicken annotation Galgal5 from Ensembl.
+#' Chicken (\emph{Gallus gallus}) annotations based on genome assembly GALGAL5 from Ensembl.
+#'
+#' Variables:
+#'
+#' \itemize{
+#'   \item ensgene 
+#'   \item entrez 
+#'   \item symbol 
+#'   \item chr 
+#'   \item start 
+#'   \item end 
+#'   \item strand 
+#'   \item biotype 
+#'   \item description 
+#' }
 #'
 #' @examples
 #' head(galgal5)
 #'
-#' @source \url{http://useast.ensembl.org/Gallus_gallus}
+#' @source \url{http://ensembl.org/gallus_gallus}
+#' @docType data
+#' @keywords datasets
 "galgal5"

--- a/R/galgal5_tx2gene.R
+++ b/R/galgal5_tx2gene.R
@@ -1,6 +1,6 @@
 #' Chicken transcripts to genes
 #'
-#' Lookup table for converting Chicken (\emph{Gallus gallus}) Ensembl transcript IDs to gene IDs based on genome assembly GALGAL5_TX2GENE from Ensembl.
+#' Lookup table for converting Chicken (\emph{Gallus gallus}) Ensembl transcript IDs to gene IDs based on genome assembly GALGAL5 from Ensembl.
 #'
 #' Variables:
 #'

--- a/R/galgal5_tx2gene.R
+++ b/R/galgal5_tx2gene.R
@@ -1,9 +1,18 @@
-#' Chicken (galgal5) transcripts to genes
+#' Chicken transcripts to genes
 #'
-#' Chicken (galgal5) Ensembl transcript IDs to gene IDs.
+#' Lookup table for converting Chicken (\emph{Gallus gallus}) Ensembl transcript IDs to gene IDs based on genome assembly GALGAL5_TX2GENE from Ensembl.
+#'
+#' Variables:
+#'
+#' \itemize{
+#'   \item enstxp 
+#'   \item ensgene 
+#' }
 #'
 #' @examples
 #' head(galgal5_tx2gene)
 #'
-#' @source \url{http://www.ensembl.org/}
+#' @source \url{http://ensembl.org/gallus_gallus}
+#' @docType data
+#' @keywords datasets
 "galgal5_tx2gene"

--- a/R/grch37.R
+++ b/R/grch37.R
@@ -1,9 +1,25 @@
-#' Human annotation GRCh37
+#' Human annotation data
 #'
-#' Human annotation GRCh37 from Ensembl release 75.
+#' Human (\emph{Homo sapiens}) annotations based on genome assembly GRCH37 from Ensembl.
+#'
+#' Variables:
+#'
+#' \itemize{
+#'   \item ensgene 
+#'   \item entrez 
+#'   \item symbol 
+#'   \item chr 
+#'   \item start 
+#'   \item end 
+#'   \item strand 
+#'   \item biotype 
+#'   \item description 
+#' }
 #'
 #' @examples
 #' head(grch37)
 #'
-#' @source \url{http://grch37.ensembl.org/}
+#' @source \url{http://ensembl.org/homo_sapiens}
+#' @docType data
+#' @keywords datasets
 "grch37"

--- a/R/grch37_tx2gene.R
+++ b/R/grch37_tx2gene.R
@@ -1,9 +1,18 @@
-#' Human GRCh37 transcripts to genes
+#' Human transcripts to genes
 #'
-#' Human GRCh37  Ensembl transcript IDs to gene IDs.
+#' Lookup table for converting Human (\emph{Homo sapiens}) Ensembl transcript IDs to gene IDs based on genome assembly GRCH37_TX2GENE from Ensembl.
+#'
+#' Variables:
+#'
+#' \itemize{
+#'   \item enstxp 
+#'   \item ensgene 
+#' }
 #'
 #' @examples
 #' head(grch37_tx2gene)
 #'
-#' @source \url{http://www.ensembl.org/}
+#' @source \url{http://ensembl.org/homo_sapiens}
+#' @docType data
+#' @keywords datasets
 "grch37_tx2gene"

--- a/R/grch37_tx2gene.R
+++ b/R/grch37_tx2gene.R
@@ -1,6 +1,6 @@
 #' Human transcripts to genes
 #'
-#' Lookup table for converting Human (\emph{Homo sapiens}) Ensembl transcript IDs to gene IDs based on genome assembly GRCH37_TX2GENE from Ensembl.
+#' Lookup table for converting Human (\emph{Homo sapiens}) Ensembl transcript IDs to gene IDs based on genome assembly GRCH37 from Ensembl.
 #'
 #' Variables:
 #'

--- a/R/grch38.R
+++ b/R/grch38.R
@@ -1,9 +1,25 @@
-#' Human annotation GRCh38
+#' Human annotation data
 #'
-#' Human annotation GRCh38 from Ensembl.
+#' Human (\emph{Homo sapiens}) annotations based on genome assembly GRCH38 from Ensembl.
+#'
+#' Variables:
+#'
+#' \itemize{
+#'   \item ensgene 
+#'   \item entrez 
+#'   \item symbol 
+#'   \item chr 
+#'   \item start 
+#'   \item end 
+#'   \item strand 
+#'   \item biotype 
+#'   \item description 
+#' }
 #'
 #' @examples
 #' head(grch38)
 #'
-#' @source \url{http://useast.ensembl.org/Homo_sapiens}
+#' @source \url{http://ensembl.org/homo_sapiens}
+#' @docType data
+#' @keywords datasets
 "grch38"

--- a/R/grch38_tx2gene.R
+++ b/R/grch38_tx2gene.R
@@ -1,9 +1,18 @@
-#' Human GRCh38 transcripts to genes
+#' Human transcripts to genes
 #'
-#' Human GRCh38 Ensembl transcript IDs to gene IDs.
+#' Lookup table for converting Human (\emph{Homo sapiens}) Ensembl transcript IDs to gene IDs based on genome assembly GRCH38_TX2GENE from Ensembl.
+#'
+#' Variables:
+#'
+#' \itemize{
+#'   \item enstxp 
+#'   \item ensgene 
+#' }
 #'
 #' @examples
 #' head(grch38_tx2gene)
 #'
-#' @source \url{http://www.ensembl.org/}
+#' @source \url{http://ensembl.org/homo_sapiens}
+#' @docType data
+#' @keywords datasets
 "grch38_tx2gene"

--- a/R/grch38_tx2gene.R
+++ b/R/grch38_tx2gene.R
@@ -1,6 +1,6 @@
 #' Human transcripts to genes
 #'
-#' Lookup table for converting Human (\emph{Homo sapiens}) Ensembl transcript IDs to gene IDs based on genome assembly GRCH38_TX2GENE from Ensembl.
+#' Lookup table for converting Human (\emph{Homo sapiens}) Ensembl transcript IDs to gene IDs based on genome assembly GRCH38 from Ensembl.
 #'
 #' Variables:
 #'

--- a/R/grcm38.R
+++ b/R/grcm38.R
@@ -1,9 +1,25 @@
-#' Mouse annotation GRCm38
+#' Mouse annotation data
 #'
-#' Mouse annotation GRCm38 from Ensembl.
+#' Mouse (\emph{Mus musculus}) annotations based on genome assembly GRCM38 from Ensembl.
+#'
+#' Variables:
+#'
+#' \itemize{
+#'   \item ensgene 
+#'   \item entrez 
+#'   \item symbol 
+#'   \item chr 
+#'   \item start 
+#'   \item end 
+#'   \item strand 
+#'   \item biotype 
+#'   \item description 
+#' }
 #'
 #' @examples
 #' head(grcm38)
 #'
-#' @source \url{http://useast.ensembl.org/Mus_musculus}
+#' @source \url{http://ensembl.org/mus_musculus}
+#' @docType data
+#' @keywords datasets
 "grcm38"

--- a/R/grcm38_tx2gene.R
+++ b/R/grcm38_tx2gene.R
@@ -1,9 +1,18 @@
-#' Mouse GRCm38 transcripts to genes
+#' Mouse transcripts to genes
 #'
-#' Mouse GRCm38 Ensembl transcript IDs to gene IDs.
+#' Lookup table for converting Mouse (\emph{Mus musculus}) Ensembl transcript IDs to gene IDs based on genome assembly GRCM38_TX2GENE from Ensembl.
+#'
+#' Variables:
+#'
+#' \itemize{
+#'   \item enstxp 
+#'   \item ensgene 
+#' }
 #'
 #' @examples
 #' head(grcm38_tx2gene)
 #'
-#' @source \url{http://www.ensembl.org/}
+#' @source \url{http://ensembl.org/mus_musculus}
+#' @docType data
+#' @keywords datasets
 "grcm38_tx2gene"

--- a/R/grcm38_tx2gene.R
+++ b/R/grcm38_tx2gene.R
@@ -1,6 +1,6 @@
 #' Mouse transcripts to genes
 #'
-#' Lookup table for converting Mouse (\emph{Mus musculus}) Ensembl transcript IDs to gene IDs based on genome assembly GRCM38_TX2GENE from Ensembl.
+#' Lookup table for converting Mouse (\emph{Mus musculus}) Ensembl transcript IDs to gene IDs based on genome assembly GRCM38 from Ensembl.
 #'
 #' Variables:
 #'

--- a/R/rnor6.R
+++ b/R/rnor6.R
@@ -1,9 +1,25 @@
-#' Rat annotation Rnor_6.0
+#' Rat annotation data
 #'
-#' Rat annotation Rnor_6.0 from Ensembl.
+#' Rat (\emph{Rattus norvegicus}) annotations based on genome assembly RNOR6 from Ensembl.
+#'
+#' Variables:
+#'
+#' \itemize{
+#'   \item ensgene 
+#'   \item entrez 
+#'   \item symbol 
+#'   \item chr 
+#'   \item start 
+#'   \item end 
+#'   \item strand 
+#'   \item biotype 
+#'   \item description 
+#' }
 #'
 #' @examples
 #' head(rnor6)
 #'
-#' @source \url{http://useast.ensembl.org/Rattus_norvegicus}
+#' @source \url{http://ensembl.org/rattus_norvegicus}
+#' @docType data
+#' @keywords datasets
 "rnor6"

--- a/R/rnor6_tx2gene.R
+++ b/R/rnor6_tx2gene.R
@@ -1,6 +1,6 @@
 #' Rat transcripts to genes
 #'
-#' Lookup table for converting Rat (\emph{Rattus norvegicus}) Ensembl transcript IDs to gene IDs based on genome assembly RNOR6_TX2GENE from Ensembl.
+#' Lookup table for converting Rat (\emph{Rattus norvegicus}) Ensembl transcript IDs to gene IDs based on genome assembly RNOR6 from Ensembl.
 #'
 #' Variables:
 #'

--- a/R/rnor6_tx2gene.R
+++ b/R/rnor6_tx2gene.R
@@ -1,9 +1,18 @@
-#' Rat rnor6 transcripts to genes
+#' Rat transcripts to genes
 #'
-#' Rat rnor6 Ensembl transcript IDs to gene IDs.
+#' Lookup table for converting Rat (\emph{Rattus norvegicus}) Ensembl transcript IDs to gene IDs based on genome assembly RNOR6_TX2GENE from Ensembl.
+#'
+#' Variables:
+#'
+#' \itemize{
+#'   \item enstxp 
+#'   \item ensgene 
+#' }
 #'
 #' @examples
 #' head(rnor6_tx2gene)
 #'
-#' @source \url{http://www.ensembl.org/}
+#' @source \url{http://ensembl.org/rattus_norvegicus}
+#' @docType data
+#' @keywords datasets
 "rnor6_tx2gene"

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,0 +1,28 @@
+# Generate annotable documentation based on recipe
+document_annotable <- function(x, table, type) {
+  type <- match.arg(type, c("gene", "tx2gene"))
+  template.path <- system.file("inst/templates",
+                               paste0(type, ".R"),
+                               package = "annotables",
+                               mustWork = TRUE)
+
+  table.path <- system.file("data", paste0(table, ".rda"), package = "annotables")
+  stopifnot(file.exists(table.path))
+
+  file.path <- file.path("R", paste0(table, ".R"))
+
+  data <- list(
+    table = table,
+    assembly = sub("_TX2GENE", "", toupper(table)),
+    name = x$name,
+    species = x$species,
+    attributes = names(x$attributes),
+    path = sub(" ", "_", tolower(x$species))
+  )
+
+  rendered <- whisker::whisker.render(readLines(template.path), data)
+  # workaround for github.com/edwindj/whisker/issues/20
+  rendered <- gsub("(\\{) | (\\})", "\\1\\2", rendered)
+
+  writeLines(rendered, file.path)
+}

--- a/R/wbcel235.R
+++ b/R/wbcel235.R
@@ -1,9 +1,25 @@
-#' Worm annotation WBcel235
+#' Roundworm annotation data
 #'
-#' Worm annotation WBcel235 from Ensembl.
+#' Roundworm (\emph{Caenorhabditis elegans}) annotations based on genome assembly WBCEL235 from Ensembl.
+#'
+#' Variables:
+#'
+#' \itemize{
+#'   \item ensgene 
+#'   \item entrez 
+#'   \item symbol 
+#'   \item chr 
+#'   \item start 
+#'   \item end 
+#'   \item strand 
+#'   \item biotype 
+#'   \item description 
+#' }
 #'
 #' @examples
 #' head(wbcel235)
 #'
-#' @source \url{http://useast.ensembl.org/Caenorhabditis_elegans}
+#' @source \url{http://ensembl.org/caenorhabditis_elegans}
+#' @docType data
+#' @keywords datasets
 "wbcel235"

--- a/R/wbcel235_tx2gene.R
+++ b/R/wbcel235_tx2gene.R
@@ -1,9 +1,18 @@
-#' C. elegans wbcel235 transcripts to genes
+#' Roundworm transcripts to genes
 #'
-#' C. elegans wbcel235 Ensembl transcript IDs to gene IDs.
+#' Lookup table for converting Roundworm (\emph{Caenorhabditis elegans}) Ensembl transcript IDs to gene IDs based on genome assembly WBCEL235_TX2GENE from Ensembl.
+#'
+#' Variables:
+#'
+#' \itemize{
+#'   \item enstxp 
+#'   \item ensgene 
+#' }
 #'
 #' @examples
 #' head(wbcel235_tx2gene)
 #'
-#' @source \url{http://www.ensembl.org/}
+#' @source \url{http://ensembl.org/caenorhabditis_elegans}
+#' @docType data
+#' @keywords datasets
 "wbcel235_tx2gene"

--- a/R/wbcel235_tx2gene.R
+++ b/R/wbcel235_tx2gene.R
@@ -1,6 +1,6 @@
 #' Roundworm transcripts to genes
 #'
-#' Lookup table for converting Roundworm (\emph{Caenorhabditis elegans}) Ensembl transcript IDs to gene IDs based on genome assembly WBCEL235_TX2GENE from Ensembl.
+#' Lookup table for converting Roundworm (\emph{Caenorhabditis elegans}) Ensembl transcript IDs to gene IDs based on genome assembly WBCEL235 from Ensembl.
 #'
 #' Variables:
 #'

--- a/data-raw/build-annotables.r
+++ b/data-raw/build-annotables.r
@@ -38,6 +38,9 @@ genetables <- Map(tidy_data, genetables, recipes)
 # export data
 Map(save_data, genetables, name = names(genetables))
 
+# document
+Map(document_annotable, recipes, names(recipes), type = "gene")
+
 # transcript 2 gene -------------------------------------------------------
 names(recipes) <- paste0(names(recipes), "_tx2gene")
 
@@ -56,3 +59,6 @@ tx2gene <- Map(tidy_data, tx2gene, recipes)
 
 # export data
 Map(save_data, tx2gene, name = names(tx2gene))
+
+# document
+Map(document_annotable, recipes, names(recipes), type = "tx2gene")

--- a/data-raw/recipes/bdgp6.yml
+++ b/data-raw/recipes/bdgp6.yml
@@ -1,3 +1,5 @@
+name: Fruitfly
+species: Drosophila melanogaster
 host: ensembl.org
 biomart: ENSEMBL_MART_ENSEMBL
 dataset: dmelanogaster_gene_ensembl

--- a/data-raw/recipes/galgal5.yml
+++ b/data-raw/recipes/galgal5.yml
@@ -1,3 +1,5 @@
+name: Chicken
+species: Gallus gallus
 host: ensembl.org
 biomart: ENSEMBL_MART_ENSEMBL
 dataset: ggallus_gene_ensembl

--- a/data-raw/recipes/grch37.yml
+++ b/data-raw/recipes/grch37.yml
@@ -1,3 +1,5 @@
+name: Human
+species: Homo sapiens
 host: grch37.ensembl.org
 biomart: ENSEMBL_MART_ENSEMBL
 dataset: hsapiens_gene_ensembl

--- a/data-raw/recipes/grch38.yml
+++ b/data-raw/recipes/grch38.yml
@@ -1,3 +1,5 @@
+name: Human
+species: Homo sapiens
 host: ensembl.org
 biomart: ENSEMBL_MART_ENSEMBL
 dataset: hsapiens_gene_ensembl

--- a/data-raw/recipes/grcm38.yml
+++ b/data-raw/recipes/grcm38.yml
@@ -1,3 +1,5 @@
+name: Mouse
+species: Mus musculus
 host: ensembl.org
 biomart: ENSEMBL_MART_ENSEMBL
 dataset: mmusculus_gene_ensembl

--- a/data-raw/recipes/rnor6.yml
+++ b/data-raw/recipes/rnor6.yml
@@ -1,3 +1,5 @@
+name: Rat
+species: Rattus norvegicus
 host: ensembl.org
 biomart: ENSEMBL_MART_ENSEMBL
 dataset: rnorvegicus_gene_ensembl

--- a/data-raw/recipes/wbcel235.yml
+++ b/data-raw/recipes/wbcel235.yml
@@ -1,3 +1,5 @@
+name: Roundworm
+species: Caenorhabditis elegans
 host: ensembl.org
 biomart: ENSEMBL_MART_ENSEMBL
 dataset: celegans_gene_ensembl

--- a/inst/templates/gene.R
+++ b/inst/templates/gene.R
@@ -1,0 +1,18 @@
+{{=<% %>=}}
+#' <% name %> annotation data
+#'
+#' <% name %> (\emph{ <% species %> }) annotations based on genome assembly <% assembly %> from Ensembl.
+#'
+#' Variables:
+#'
+#' \itemize{ <%# attributes %>
+#'   \item <% . %> <%/ attributes %>
+#'  }
+#'
+#' @examples
+#' head(<% table %>)
+#'
+#' @source \url{http://ensembl.org/<% path %> }
+#' @docType data
+#' @keywords datasets
+"<% table %>"

--- a/inst/templates/tx2gene.R
+++ b/inst/templates/tx2gene.R
@@ -1,0 +1,18 @@
+{{=<% %>=}}
+#' <% name %> transcripts to genes
+#'
+#' Lookup table for converting <% name %> (\emph{ <% species %> }) Ensembl transcript IDs to gene IDs based on genome assembly <% assembly %> from Ensembl.
+#'
+#' Variables:
+#'
+#' \itemize{ <%# attributes %>
+#'   \item <% . %> <%/ attributes %>
+#'  }
+#'
+#' @examples
+#' head(<% table %>)
+#'
+#' @source \url{http://ensembl.org/<% path %> }
+#' @docType data
+#' @keywords datasets
+"<% table %>"

--- a/man/bdgp6.Rd
+++ b/man/bdgp6.Rd
@@ -3,16 +3,31 @@
 \docType{data}
 \name{bdgp6}
 \alias{bdgp6}
-\title{Fly annotation BDGP6}
+\title{Fruitfly annotation data}
 \format{An object of class \code{tbl_df} (inherits from \code{tbl}, \code{data.frame}) with 19639 rows and 9 columns.}
 \source{
-\url{http://useast.ensembl.org/Drosophila_melanogaster}
+\url{http://ensembl.org/drosophila_melanogaster}
 }
 \usage{
 bdgp6
 }
 \description{
-Fly annotation BDGP6 from Ensembl.
+Fruitfly (\emph{Drosophila melanogaster}) annotations based on genome assembly BDGP6 from Ensembl.
+}
+\details{
+Variables:
+
+\itemize{
+  \item ensgene 
+  \item entrez 
+  \item symbol 
+  \item chr 
+  \item start 
+  \item end 
+  \item strand 
+  \item biotype 
+  \item description 
+}
 }
 \examples{
 head(bdgp6)

--- a/man/bdgp6_tx2gene.Rd
+++ b/man/bdgp6_tx2gene.Rd
@@ -3,16 +3,24 @@
 \docType{data}
 \name{bdgp6_tx2gene}
 \alias{bdgp6_tx2gene}
-\title{Fly BDGP6 transcripts to genes}
+\title{Fruitfly transcripts to genes}
 \format{An object of class \code{tbl_df} (inherits from \code{tbl}, \code{data.frame}) with 34749 rows and 2 columns.}
 \source{
-\url{http://www.ensembl.org/}
+\url{http://ensembl.org/drosophila_melanogaster}
 }
 \usage{
 bdgp6_tx2gene
 }
 \description{
-Fly BDGP6 Ensembl transcript IDs to gene IDs.
+Lookup table for converting Fruitfly (\emph{Drosophila melanogaster}) Ensembl transcript IDs to gene IDs based on genome assembly BDGP6 from Ensembl.
+}
+\details{
+Variables:
+
+\itemize{
+  \item enstxp 
+  \item ensgene 
+}
 }
 \examples{
 head(bdgp6_tx2gene)

--- a/man/galgal5.Rd
+++ b/man/galgal5.Rd
@@ -3,16 +3,31 @@
 \docType{data}
 \name{galgal5}
 \alias{galgal5}
-\title{Chicken annotation Galgal5}
+\title{Chicken annotation data}
 \format{An object of class \code{tbl_df} (inherits from \code{tbl}, \code{data.frame}) with 25677 rows and 9 columns.}
 \source{
-\url{http://useast.ensembl.org/Gallus_gallus}
+\url{http://ensembl.org/gallus_gallus}
 }
 \usage{
 galgal5
 }
 \description{
-Chicken annotation Galgal5 from Ensembl.
+Chicken (\emph{Gallus gallus}) annotations based on genome assembly GALGAL5 from Ensembl.
+}
+\details{
+Variables:
+
+\itemize{
+  \item ensgene 
+  \item entrez 
+  \item symbol 
+  \item chr 
+  \item start 
+  \item end 
+  \item strand 
+  \item biotype 
+  \item description 
+}
 }
 \examples{
 head(galgal5)

--- a/man/galgal5_tx2gene.Rd
+++ b/man/galgal5_tx2gene.Rd
@@ -3,16 +3,24 @@
 \docType{data}
 \name{galgal5_tx2gene}
 \alias{galgal5_tx2gene}
-\title{Chicken (galgal5) transcripts to genes}
+\title{Chicken transcripts to genes}
 \format{An object of class \code{tbl_df} (inherits from \code{tbl}, \code{data.frame}) with 38118 rows and 2 columns.}
 \source{
-\url{http://www.ensembl.org/}
+\url{http://ensembl.org/gallus_gallus}
 }
 \usage{
 galgal5_tx2gene
 }
 \description{
-Chicken (galgal5) Ensembl transcript IDs to gene IDs.
+Lookup table for converting Chicken (\emph{Gallus gallus}) Ensembl transcript IDs to gene IDs based on genome assembly GALGAL5 from Ensembl.
+}
+\details{
+Variables:
+
+\itemize{
+  \item enstxp 
+  \item ensgene 
+}
 }
 \examples{
 head(galgal5_tx2gene)

--- a/man/grch37.Rd
+++ b/man/grch37.Rd
@@ -3,16 +3,31 @@
 \docType{data}
 \name{grch37}
 \alias{grch37}
-\title{Human annotation GRCh37}
+\title{Human annotation data}
 \format{An object of class \code{tbl_df} (inherits from \code{tbl}, \code{data.frame}) with 66978 rows and 9 columns.}
 \source{
-\url{http://grch37.ensembl.org/}
+\url{http://ensembl.org/homo_sapiens}
 }
 \usage{
 grch37
 }
 \description{
-Human annotation GRCh37 from Ensembl release 75.
+Human (\emph{Homo sapiens}) annotations based on genome assembly GRCH37 from Ensembl.
+}
+\details{
+Variables:
+
+\itemize{
+  \item ensgene 
+  \item entrez 
+  \item symbol 
+  \item chr 
+  \item start 
+  \item end 
+  \item strand 
+  \item biotype 
+  \item description 
+}
 }
 \examples{
 head(grch37)

--- a/man/grch37_tx2gene.Rd
+++ b/man/grch37_tx2gene.Rd
@@ -3,16 +3,24 @@
 \docType{data}
 \name{grch37_tx2gene}
 \alias{grch37_tx2gene}
-\title{Human GRCh37 transcripts to genes}
+\title{Human transcripts to genes}
 \format{An object of class \code{tbl_df} (inherits from \code{tbl}, \code{data.frame}) with 215170 rows and 2 columns.}
 \source{
-\url{http://www.ensembl.org/}
+\url{http://ensembl.org/homo_sapiens}
 }
 \usage{
 grch37_tx2gene
 }
 \description{
-Human GRCh37  Ensembl transcript IDs to gene IDs.
+Lookup table for converting Human (\emph{Homo sapiens}) Ensembl transcript IDs to gene IDs based on genome assembly GRCH37 from Ensembl.
+}
+\details{
+Variables:
+
+\itemize{
+  \item enstxp 
+  \item ensgene 
+}
 }
 \examples{
 head(grch37_tx2gene)

--- a/man/grch38.Rd
+++ b/man/grch38.Rd
@@ -3,16 +3,31 @@
 \docType{data}
 \name{grch38}
 \alias{grch38}
-\title{Human annotation GRCh38}
+\title{Human annotation data}
 \format{An object of class \code{tbl_df} (inherits from \code{tbl}, \code{data.frame}) with 64101 rows and 9 columns.}
 \source{
-\url{http://useast.ensembl.org/Homo_sapiens}
+\url{http://ensembl.org/homo_sapiens}
 }
 \usage{
 grch38
 }
 \description{
-Human annotation GRCh38 from Ensembl.
+Human (\emph{Homo sapiens}) annotations based on genome assembly GRCH38 from Ensembl.
+}
+\details{
+Variables:
+
+\itemize{
+  \item ensgene 
+  \item entrez 
+  \item symbol 
+  \item chr 
+  \item start 
+  \item end 
+  \item strand 
+  \item biotype 
+  \item description 
+}
 }
 \examples{
 head(grch38)

--- a/man/grch38_tx2gene.Rd
+++ b/man/grch38_tx2gene.Rd
@@ -3,16 +3,24 @@
 \docType{data}
 \name{grch38_tx2gene}
 \alias{grch38_tx2gene}
-\title{Human GRCh38 transcripts to genes}
+\title{Human transcripts to genes}
 \format{An object of class \code{tbl_df} (inherits from \code{tbl}, \code{data.frame}) with 215929 rows and 2 columns.}
 \source{
-\url{http://www.ensembl.org/}
+\url{http://ensembl.org/homo_sapiens}
 }
 \usage{
 grch38_tx2gene
 }
 \description{
-Human GRCh38 Ensembl transcript IDs to gene IDs.
+Lookup table for converting Human (\emph{Homo sapiens}) Ensembl transcript IDs to gene IDs based on genome assembly GRCH38 from Ensembl.
+}
+\details{
+Variables:
+
+\itemize{
+  \item enstxp 
+  \item ensgene 
+}
 }
 \examples{
 head(grch38_tx2gene)

--- a/man/grcm38.Rd
+++ b/man/grcm38.Rd
@@ -3,16 +3,31 @@
 \docType{data}
 \name{grcm38}
 \alias{grcm38}
-\title{Mouse annotation GRCm38}
+\title{Mouse annotation data}
 \format{An object of class \code{tbl_df} (inherits from \code{tbl}, \code{data.frame}) with 50730 rows and 9 columns.}
 \source{
-\url{http://useast.ensembl.org/Mus_musculus}
+\url{http://ensembl.org/mus_musculus}
 }
 \usage{
 grcm38
 }
 \description{
-Mouse annotation GRCm38 from Ensembl.
+Mouse (\emph{Mus musculus}) annotations based on genome assembly GRCM38 from Ensembl.
+}
+\details{
+Variables:
+
+\itemize{
+  \item ensgene 
+  \item entrez 
+  \item symbol 
+  \item chr 
+  \item start 
+  \item end 
+  \item strand 
+  \item biotype 
+  \item description 
+}
 }
 \examples{
 head(grcm38)

--- a/man/grcm38_tx2gene.Rd
+++ b/man/grcm38_tx2gene.Rd
@@ -3,16 +3,24 @@
 \docType{data}
 \name{grcm38_tx2gene}
 \alias{grcm38_tx2gene}
-\title{Mouse GRCm38 transcripts to genes}
+\title{Mouse transcripts to genes}
 \format{An object of class \code{tbl_df} (inherits from \code{tbl}, \code{data.frame}) with 124168 rows and 2 columns.}
 \source{
-\url{http://www.ensembl.org/}
+\url{http://ensembl.org/mus_musculus}
 }
 \usage{
 grcm38_tx2gene
 }
 \description{
-Mouse GRCm38 Ensembl transcript IDs to gene IDs.
+Lookup table for converting Mouse (\emph{Mus musculus}) Ensembl transcript IDs to gene IDs based on genome assembly GRCM38 from Ensembl.
+}
+\details{
+Variables:
+
+\itemize{
+  \item enstxp 
+  \item ensgene 
+}
 }
 \examples{
 head(grcm38_tx2gene)

--- a/man/rnor6.Rd
+++ b/man/rnor6.Rd
@@ -3,16 +3,31 @@
 \docType{data}
 \name{rnor6}
 \alias{rnor6}
-\title{Rat annotation Rnor_6.0}
+\title{Rat annotation data}
 \format{An object of class \code{tbl_df} (inherits from \code{tbl}, \code{data.frame}) with 33815 rows and 9 columns.}
 \source{
-\url{http://useast.ensembl.org/Rattus_norvegicus}
+\url{http://ensembl.org/rattus_norvegicus}
 }
 \usage{
 rnor6
 }
 \description{
-Rat annotation Rnor_6.0 from Ensembl.
+Rat (\emph{Rattus norvegicus}) annotations based on genome assembly RNOR6 from Ensembl.
+}
+\details{
+Variables:
+
+\itemize{
+  \item ensgene 
+  \item entrez 
+  \item symbol 
+  \item chr 
+  \item start 
+  \item end 
+  \item strand 
+  \item biotype 
+  \item description 
+}
 }
 \examples{
 head(rnor6)

--- a/man/rnor6_tx2gene.Rd
+++ b/man/rnor6_tx2gene.Rd
@@ -3,16 +3,24 @@
 \docType{data}
 \name{rnor6_tx2gene}
 \alias{rnor6_tx2gene}
-\title{Rat rnor6 transcripts to genes}
+\title{Rat transcripts to genes}
 \format{An object of class \code{tbl_df} (inherits from \code{tbl}, \code{data.frame}) with 40459 rows and 2 columns.}
 \source{
-\url{http://www.ensembl.org/}
+\url{http://ensembl.org/rattus_norvegicus}
 }
 \usage{
 rnor6_tx2gene
 }
 \description{
-Rat rnor6 Ensembl transcript IDs to gene IDs.
+Lookup table for converting Rat (\emph{Rattus norvegicus}) Ensembl transcript IDs to gene IDs based on genome assembly RNOR6 from Ensembl.
+}
+\details{
+Variables:
+
+\itemize{
+  \item enstxp 
+  \item ensgene 
+}
 }
 \examples{
 head(rnor6_tx2gene)

--- a/man/wbcel235.Rd
+++ b/man/wbcel235.Rd
@@ -3,16 +3,31 @@
 \docType{data}
 \name{wbcel235}
 \alias{wbcel235}
-\title{Worm annotation WBcel235}
+\title{Roundworm annotation data}
 \format{An object of class \code{tbl_df} (inherits from \code{tbl}, \code{data.frame}) with 47065 rows and 9 columns.}
 \source{
-\url{http://useast.ensembl.org/Caenorhabditis_elegans}
+\url{http://ensembl.org/caenorhabditis_elegans}
 }
 \usage{
 wbcel235
 }
 \description{
-Worm annotation WBcel235 from Ensembl.
+Roundworm (\emph{Caenorhabditis elegans}) annotations based on genome assembly WBCEL235 from Ensembl.
+}
+\details{
+Variables:
+
+\itemize{
+  \item ensgene 
+  \item entrez 
+  \item symbol 
+  \item chr 
+  \item start 
+  \item end 
+  \item strand 
+  \item biotype 
+  \item description 
+}
 }
 \examples{
 head(wbcel235)

--- a/man/wbcel235_tx2gene.Rd
+++ b/man/wbcel235_tx2gene.Rd
@@ -3,16 +3,24 @@
 \docType{data}
 \name{wbcel235_tx2gene}
 \alias{wbcel235_tx2gene}
-\title{C. elegans wbcel235 transcripts to genes}
+\title{Roundworm transcripts to genes}
 \format{An object of class \code{tbl_df} (inherits from \code{tbl}, \code{data.frame}) with 58941 rows and 2 columns.}
 \source{
-\url{http://www.ensembl.org/}
+\url{http://ensembl.org/caenorhabditis_elegans}
 }
 \usage{
 wbcel235_tx2gene
 }
 \description{
-C. elegans wbcel235 Ensembl transcript IDs to gene IDs.
+Lookup table for converting Roundworm (\emph{Caenorhabditis elegans}) Ensembl transcript IDs to gene IDs based on genome assembly WBCEL235 from Ensembl.
+}
+\details{
+Variables:
+
+\itemize{
+  \item enstxp 
+  \item ensgene 
+}
 }
 \examples{
 head(wbcel235_tx2gene)


### PR DESCRIPTION
Manually writing/updating documentation files... are we animals? 😉

This adds a (unexported) function, `document_annotable()`, that uses [mustache](https://mustache.github.io)-based templates (located in `inst/templates`) and annotable recipes to generate R scripts in `R/` containing (hopefully) all relevant documentation info for a table.

Note, this adds [whisker](https://github.com/edwindj/whisker) as a suggested dependency. 